### PR TITLE
增加一个简单的消抖功能，以解决无法彻底关机的问题

### DIFF
--- a/1.Firmware/src/hal/hal.cpp
+++ b/1.Firmware/src/hal/hal.cpp
@@ -15,8 +15,7 @@ void HAL::Init()
         Serial.printf("lv_port_disp_init malloc failed!\n");
     knob_init();
     power_init();
-    if(! knob_check_long_pressed(1000))
-    {
+    if(! knob_check_long_pressed(1000)){
         power_off();
     }
     motor_init();

--- a/1.Firmware/src/hal/hal.cpp
+++ b/1.Firmware/src/hal/hal.cpp
@@ -13,10 +13,14 @@ void HAL::Init()
     disp_draw_buf = static_cast<lv_color_t*>(malloc(DISP_BUF_SIZE * sizeof(lv_color_t)));
     if (disp_draw_buf == nullptr)
         Serial.printf("lv_port_disp_init malloc failed!\n");
+    knob_init();
     power_init();
+    if(! knob_check_long_pressed(1000))
+    {
+        power_off();
+    }
     motor_init();
 
-    knob_init();
     // super_dial_init();
 }
 

--- a/1.Firmware/src/hal/hal.h
+++ b/1.Firmware/src/hal/hal.h
@@ -24,6 +24,7 @@ namespace HAL
     void Init();
     void Update();
 
+    bool knob_check_long_pressed(int should_cnt);
     void knob_init();
     void knob_update(void);
     bool encoder_is_pushed(void);

--- a/1.Firmware/src/hal/knob.cpp
+++ b/1.Firmware/src/hal/knob.cpp
@@ -68,3 +68,22 @@ void HAL::knob_init(void)
     // push_button.EventAttach(button_handler);
 
 }
+
+bool HAL::knob_check_long_pressed(int should_cnt)
+{
+    int press_cnt = 0;
+    for(int i = 0; i < should_cnt * 2; i++)
+    {
+        if (digitalRead(PUSH_BUTTON_PIN) == LOW)
+        {
+            press_cnt++;
+        }
+    }
+    if(press_cnt >= should_cnt)
+    {
+        return true;
+    }else
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
经常碰到关机立刻开机的情况，可能按键装配的时候太紧了。。。
启动的时候添加一个消抖可以有效解决这种情况的发生。